### PR TITLE
switch to hexadecimal

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,6 @@
  * @returns true if the argument is a valid UUID or false if it's not
  */
 function validator(arg: string): boolean{
-	return /([0-9A-Z]{8})-([0-9A-Z]{4})-([0-9A-Z]{4})-([0-9A-Z]{4})-([0-9A-Z]{12})/i.test(arg);
+	return /([0-9A-F]{8})-([0-9A-F]{4})-([0-9A-F]{4})-([0-9A-F]{4})-([0-9A-F]{12})/i.test(arg);
 }
 export { validator };


### PR DESCRIPTION
Minecraft UUIDs are hexadecimal so the only letters they will ever have are A-F